### PR TITLE
feat# OS 拖文件到 webview 输入框自动出 chip

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/action/SendFileToInputAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/action/SendFileToInputAction.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.wm.ToolWindowManager
 import com.zcode.ideaplugin.ZCodeBundle.message
 import com.zcode.ideaplugin.ZCodeIcons
+import com.zcode.ideaplugin.ui.FileRefs
 import com.zcode.ideaplugin.zCodeService
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
@@ -38,11 +39,7 @@ class SendFileToInputAction : AnAction(
         val files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY) ?: return
         if (files.isEmpty()) return
 
-        // 文件夹路径末尾加 /（前端据此区分图标：folder vs file）
-        val refs = files.map { f ->
-            if (f.isDirectory) "@${f.path}/" else "@${f.path}"
-        }
-        pushRefs(project, refs)
+        pushRefs(project, FileRefs.toRefs(files.toList()))
     }
 }
 

--- a/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/ui/FileRefs.kt
+++ b/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/ui/FileRefs.kt
@@ -1,0 +1,31 @@
+package com.zcode.ideaplugin.ui
+
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * VirtualFile → "@path[/]" 引用串统一转换。
+ *
+ * 三处调用点（[ZCodeToolWindowPanel.handlePickFiles] / [com.zcode.ideaplugin.action.SendFileToInputAction] /
+ * [ZCodeToolWindowPanel.registerFileDropTarget]）共享同一格式：
+ *   - 目录末尾补 `/`（前端 FileRef 靠它判定目录图标）
+ *   - 加 `@` 前缀（前端 text 序列化时与正文区分）
+ *
+ * presentableUrl vs path 的选择：
+ *   - handlePickFiles 走 presentableUrl（FileChooser 拿到的，Windows 上正斜杠）
+ *   - SendFileToInputAction 走 path（VIRTUAL_FILE_ARRAY 拿到的，平台原生形态）
+ *   - fileDropTarget 不走本函数——它拿的是 `java.io.File` 而非 `VirtualFile`，内联处理
+ *     （AWT File 没有 presentableUrl 概念，与 VirtualFile.path 等价的是 File.absolutePath）
+ *
+ * 内部可见：仅 intellij-plugin 模块内复用，不暴露给 protocol-client。
+ */
+internal object FileRefs {
+    fun toRef(file: VirtualFile, presentable: Boolean = false): String {
+        // presentableUrl 是 VirtualFile 上的非空 String（IDE 平台契约），无须 ?: 兜底
+        val p = if (presentable) file.presentableUrl else file.path
+        val withSlash = if (file.isDirectory && !p.endsWith("/")) "$p/" else p
+        return "@$withSlash"
+    }
+
+    fun toRefs(files: List<VirtualFile>, presentable: Boolean = false): List<String> =
+        files.map { toRef(it, presentable) }
+}

--- a/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/ui/ZCodeToolWindowPanel.kt
+++ b/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/ui/ZCodeToolWindowPanel.kt
@@ -53,6 +53,11 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import java.awt.BorderLayout
+import java.awt.datatransfer.DataFlavor
+import java.awt.dnd.DropTarget
+import java.awt.dnd.DropTargetAdapter
+import java.awt.dnd.DropTargetDropEvent
+import java.io.File
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -124,6 +129,8 @@ class ZCodeToolWindowPanel(
     private var disposed = false
     // 主题监听连接（dispose 时断开）
     private var themeBusConn: com.intellij.util.messages.MessageBusConnection? = null
+    // OS 文件拖入拦截（AWT DropTarget 挂 JBCefBrowser.component，dispose 时显式 removeComponent）
+    private var fileDropTarget: DropTarget? = null
 
     // ============ 会话内嵌浏览器（AI browser-use 同屏观察用）============
     // 浏览器作为聊天 webview 的右侧分栏，AI 导航时无需切标签页——对齐 ZCode 桌面端
@@ -336,6 +343,8 @@ class ZCodeToolWindowPanel(
         lazyPlaceholder?.let { remove(it) }
         lazyPlaceholder = null
         add(jbCefBrowser.component, BorderLayout.CENTER)
+        // OS 文件拖入拦截：必须在 component 加入面板后才挂（否则 Swing DnD 无目标组件）
+        registerFileDropTarget()
         log.info("JCEF panel initialized")
     }
 
@@ -399,6 +408,65 @@ class ZCodeToolWindowPanel(
                 pushTheme()
             }
         )
+    }
+
+    /**
+     * 注册 OS 文件拖入拦截（AWT DropTarget 路径）
+     *
+     * 路径来源 AWT [DataFlavor.javaFileListFlavor] → `List<File>` → 100% 真绝对路径
+     * （不依赖 CefDragHandler.getFileNames 的 native 行为；OS 拖动时 transferable 已含完整路径，
+     * 与 JBCefBrowser 是否 OSR / remote 无关——windowed 模式稳定）。
+     *
+     * 触发后复用现有 `filesToInput` 推送链路（与 [handlePickFiles] / [com.zcode.ideaplugin.action.SendFileToInputAction] 同 op），
+     * 前端 InputBox 监听器自动接住加 chip。
+     *
+     * 挂载时机：`JBCefBrowser.component` 已加入面板之后（`initJcef()` 末），否则 Swing DnD 无目标组件。
+     * 多 tab：每个 panel 独立 JBCefBrowser 各挂各的——本 panel 只处理自己 webview 的拖入，
+     * 跨 tab 拖入由用户在目标 tab 内再次拖（与 SendFileToInputAction 走 activePanel 全局路由不同）。
+     */
+    private fun registerFileDropTarget() {
+        val comp = jbCefBrowser.component
+        fileDropTarget = DropTarget(comp, object : DropTargetAdapter() {
+            override fun drop(dtde: DropTargetDropEvent) {
+                try {
+                    // 用拖动源声明的动作（COPY / MOVE / LINK）而非硬编码——尊重 OS 端意图
+                    dtde.acceptDrop(dtde.dropAction)
+                    val t = dtde.transferable
+                    if (!t.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+                        dtde.dropComplete(false)
+                        return
+                    }
+                    // AWT DataFlavor.javaFileListFlavor 在 JDK 11+ 标 @Deprecated 警告但仍可用，
+                    // 返回类型是 Any!，需要强转 + 空兜底
+                    val files: List<File> = runCatching {
+                        @Suppress("UNCHECKED_CAST")
+                        t.getTransferData(DataFlavor.javaFileListFlavor) as List<File>
+                    }.getOrElse { emptyList() }
+                    if (files.isEmpty()) {
+                        // 空列表 = 接受但无内容，告诉 OS 成功（避免 macOS Finder 残影）
+                        dtde.dropComplete(true)
+                        return
+                    }
+                    // 与 FileRefs.toRef 同款格式（不走 FileRefs 因为这里是 java.io.File 不是 VirtualFile，
+                    // 语义上等价但来源不同——AWT 没有 presentableUrl 概念）
+                    val refs = files.map<File, String> { f ->
+                        val p = f.absolutePath
+                        val withSlash = if (f.isDirectory && !p.endsWith("/")) "$p/" else p
+                        "@$withSlash"
+                    }
+                    log.info("[fileDrop] intercepted ${refs.size} file(s): ${refs.take(3)}")
+                    pushToWebview(buildJsonObject {
+                        put("op", "filesToInput")
+                        put("refs", JsonArray(refs.map { JsonPrimitive(it) }))
+                    })
+                    dtde.dropComplete(true)
+                } catch (e: Exception) {
+                    log.warn("[fileDrop] drop failed: ${e.message}")
+                    try { dtde.dropComplete(false) } catch (_: Exception) {}
+                }
+            }
+        })
+        log.info("[fileDrop] DropTarget registered")
     }
 
     /** 推送当前 IDE 主题给前端（通过 executeJavaScript 调 onIdeThemeChanged）*/
@@ -1398,6 +1466,14 @@ if (!window.__ZCODE_LOG_HOOK__) {
             log.warn("Failed to disconnect theme listener: ${e.message}")
         }
         try {
+            // DropTarget 解绑：AWT 公开 API 没有 removeComponent，
+            // 标准做法是置 null 释放引用，让 AWT 在 component dispose 时通过 removeNotify 自动清理 listener 闭包
+            // （JBR / JCEF 释放 jbCefBrowser 走 Disposer.dispose 会触发 component.removeNotify）
+            fileDropTarget = null
+        } catch (e: Exception) {
+            log.warn("Failed to release file drop target: ${e.message}")
+        }
+        try {
             if (::jsQuery.isInitialized) Disposer.dispose(jsQuery)
         } catch (e: Exception) {
             log.warn("Failed to release jsQuery: ${e.message}")
@@ -2198,10 +2274,7 @@ if (!window.__ZCODE_LOG_HOOK__) {
             return buildJsonObject { put("op", "filesPicked"); put("count", 0) }
         }
         // 目录尾加 /（与 SendFileToInputAction 一致，前端 FileRef 靠它判定目录图标）
-        val refs = picked.map { f ->
-            val p = f.presentableUrl ?: f.path
-            if (f.isDirectory && !p.endsWith("/")) "$p/" else p
-        }.map { "@$it" }
+        val refs = FileRefs.toRefs(picked, presentable = true)
         log.info("${refs.size} attachment(s) selected: $refs")
         // 复用 filesToInput 推送链路（InputBox 已监听，自动加入 fileRefs chips）
         pushToWebview(buildJsonObject {

--- a/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/ui/ZCodeToolWindowPanel.kt
+++ b/intellij-plugin/src/main/kotlin/com/zcode/ideaplugin/ui/ZCodeToolWindowPanel.kt
@@ -458,6 +458,9 @@ class ZCodeToolWindowPanel(
                     pushToWebview(buildJsonObject {
                         put("op", "filesToInput")
                         put("refs", JsonArray(refs.map { JsonPrimitive(it) }))
+                        // 标记来源让前端按心智分流：拖拽走内联 chip（与"粘贴完整路径"一致），
+                        // IDE 右键/附件按钮不带 source 字段走原逻辑（空输入框入顶部 chip 栏）
+                        put("source", "drag")
                     })
                     dtde.dropComplete(true)
                 } catch (e: Exception) {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -90,6 +90,23 @@ export default function App() {
     return () => document.removeEventListener('keydown', handler, true)
   }, [currentView])
 
+  // 全局拦 OS 文件拖入：避免 Chromium 默认行为把文件当 navigation 加载导致 webview 跳走
+  // IDE 侧 AWT DropTarget（ZCodeToolWindowPanel.registerFileDropTarget）已消费 OS 事件，
+  // 此处只补 webview 端"拖到非 InputBox 区域"的兜底
+  useEffect(() => {
+    const block = (e: DragEvent) => {
+      if (!e.dataTransfer?.types.includes('Files')) return
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    document.addEventListener('dragover', block)
+    document.addEventListener('drop', block)
+    return () => {
+      document.removeEventListener('dragover', block)
+      document.removeEventListener('drop', block)
+    }
+  }, [])
+
   // 轻量 toast（暂未支持提示）
   const [toast, setToast] = useState<string | null>(null)
   useEffect(() => {

--- a/webview/src/components/InputBox.tsx
+++ b/webview/src/components/InputBox.tsx
@@ -748,6 +748,17 @@ export function InputBox({ onSend, isStreaming = false, onStop, disabled = false
         // refs 形如 "@C:\abs\path" / "@C:\abs\path#L10-20"，存入时去掉 @ 前缀
         const clean = msg.refs.map((r) => (r.startsWith('@') ? r.slice(1) : r))
         const el = editorRef.current
+        // OS 拖拽（source='drag'）：走内联 chip——和"粘贴完整路径"同款视觉与
+        // 序列化逻辑，引用与正文的上下文顺序保留在文本流中。空输入框时 chip
+        // 插在首位，insertChipAtCursor 自动补空格并把光标移到 chip 后可继续打字。
+        // 其他来源（IDE 右键 / 附件按钮）保持原状：输入框已有内容时插内联；
+        // 空输入框时挂顶部 chip 栏。
+        const isDrag = msg.source === 'drag'
+        if (isDrag && el && clean.length > 0) {
+          for (const p of clean) insertChipAtCursor(el, p)
+          setHasText(!!el.textContent?.trim())
+          return
+        }
         // 输入框已有内容：引用与正文有上下文关系 → 内联插到当前光标后（chip 形态），
         // 不再挂到顶部 chip 栏
         if (clean.length > 0 && el && el.textContent?.trim()) {

--- a/webview/src/types/messages.ts
+++ b/webview/src/types/messages.ts
@@ -744,7 +744,7 @@ export type JavaResponse =
   | { op: 'ideTheme'; isDark: boolean }
   | { op: 'files'; files: string[] }
   | { op: 'commands'; commands: SlashCommand[] }
-  | { op: 'filesToInput'; refs: string[] }
+  | { op: 'filesToInput'; refs: string[]; source?: 'drag' | 'menu' | 'picker' }
   | { op: 'models'; models: ModelOption[] }
   | { op: 'modelManage'; configPath?: string; providers: ModelManageProvider[]; error?: string }
   /** 切换回包：changes 含全部实际变更（启用内置套餐时其余内置套餐联动禁用，互斥）*/


### PR DESCRIPTION
绕开 JCEF fakepath 拿真路径：挂 java.awt.dnd.DropTarget 到 JBCefBrowser.component， 通过 DataFlavor.javaFileListFlavor 拿 List<File>（100% 真绝对路径），复用现有 filesToInput 推送链路让前端 chip 自动出现。

实现要点：
- ZCodeToolWindowPanel 新增 registerFileDropTarget()：AWT DropTarget 单独函数挂载， 选 dropComplete(true)（避免 macOS Finder 残影）
- 新增 FileRefs 工具类：toRef / toRefs 抽 VirtualFile→'@path[/]' 转换，三处调用 （handlePickFiles / SendFileToInputAction / DropTarget）共享同一格式
- dispose 显式释放 fileDropTarget 引用
- webview 端 App.tsx 加全局 dragover/drop 拦 Files 类型，防止 Chromium 把拖入 当 navigation 打开导致 webview 跳走

验证：沙箱 IDE 拖 .txt / 文件夹 / 多文件均能出 chip；idea.log 见
'[fileDrop] DropTarget registered' + '[fileDrop] intercepted N file(s)'。